### PR TITLE
Add onCommit to FlickTypeTextEditor.

### DIFF
--- a/Sources/FlickTypeKit/FlickTypeKit-SwiftUI.swift
+++ b/Sources/FlickTypeKit/FlickTypeKit-SwiftUI.swift
@@ -40,7 +40,9 @@ public struct FlickTypeTextEditor: View {
         startingText: self.text) { items in
           if let newText = items?.first as? String {
             self.text = newText
-            onCommit()
+            if items?.completionType == .action {
+              onCommit()
+            }
           }
       }
     }) {

--- a/Sources/FlickTypeKit/FlickTypeKit-SwiftUI.swift
+++ b/Sources/FlickTypeKit/FlickTypeKit-SwiftUI.swift
@@ -38,11 +38,10 @@ public struct FlickTypeTextEditor: View {
         allowedInputMode: .allowEmoji,
         flickType: self.mode,
         startingText: self.text) { items in
-          if let newText = items?.first as? String {
-            self.text = newText
-            if items?.completionType == .action {
-              onCommit()
-            }
+          guard let newText = items?.first as? String else { return }
+          self.text = newText
+          if items?.completionType == .action {
+            onCommit()
           }
       }
     }) {

--- a/Sources/FlickTypeKit/FlickTypeKit-SwiftUI.swift
+++ b/Sources/FlickTypeKit/FlickTypeKit-SwiftUI.swift
@@ -15,11 +15,13 @@ public struct FlickTypeTextEditor: View {
   private var text: String
   private let title: String
   private let mode: FlickType.Mode
+  private let onCommit: () -> Void
   
-  public init(title: String = "", text: Binding<String>, mode: FlickType.Mode = .ask) {
+  public init(title: String = "", text: Binding<String>, mode: FlickType.Mode = .ask, onCommit: @escaping () -> Void = {}) {
     self.title = title
     self._text = text
     self.mode = mode
+    self.onCommit = onCommit
   }
   
   public var body: some View {
@@ -38,6 +40,7 @@ public struct FlickTypeTextEditor: View {
         startingText: self.text) { items in
           if let newText = items?.first as? String {
             self.text = newText
+            onCommit()
           }
       }
     }) {


### PR DESCRIPTION
I hope this would be a welcome addition. This allows `FlickTypeTextEditor` to be used similarly to `TextField` which also features the same completion handler.

Let me know if there are any changes you would prefer.