### PR TITLE
Fix availability with Xcode 14 projects.

### DIFF
--- a/Sources/FlickTypeKit/FlickTypeKit-SwiftUI.swift
+++ b/Sources/FlickTypeKit/FlickTypeKit-SwiftUI.swift
@@ -10,7 +10,7 @@
 #if os(watchOS)
 import SwiftUI
 
-@available(watchOSApplicationExtension 6.0, *)
+@available(watchOS 6.0, watchOSApplicationExtension 6.0, *)
 public struct FlickTypeTextEditor: View {
   
   @Binding


### PR DESCRIPTION
Xcode 14 merges the WKExtension target into the WKApplication target and it seems (as of 14.3/9.4 SDK at least) that the availability check now fails when used as part of one of these projects.

This PR adds a `watchOS` availability check to fix this.