### PR TITLE
Fix build issue regarding minimum watchOS version for Xcode 14.3.1

### DIFF
--- a/Sources/FlickTypeKit/FlickTypeKit-SwiftUI.swift
+++ b/Sources/FlickTypeKit/FlickTypeKit-SwiftUI.swift
@@ -10,6 +10,7 @@
 #if os(watchOS)
 import SwiftUI
 
+@available(watchOS 6.0, *)
 @available(watchOSApplicationExtension 6.0, *)
 public struct FlickTypeTextEditor: View {
   


### PR DESCRIPTION
I don't know why with 14.3.1 this started happening but I'm seeing build issues if this statement isn't added.

Please try it out before merging, you probably know all the possible edge cases better than I do, I can only say it works for me